### PR TITLE
[DO NOT MERGE, FOR REFERENCE ONLY] bootstrap: add snapshot tests for {install, install src}

### DIFF
--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -87,6 +87,12 @@ impl Step for Docs {
         // from a shared directory.
         builder.run_default_doc_steps();
 
+        // In case no default doc steps are run for host, it is possible that `<host>/doc` directory
+        // is never created.
+        if !builder.config.dry_run() {
+            t!(fs::create_dir_all(builder.doc_out(host)));
+        }
+
         let dest = "share/doc/rust/html";
 
         let mut tarball = Tarball::new(builder, "rust-docs", &host.triple);


### PR DESCRIPTION
There's still some fishy behavior going on with `builder.run_default_doc_steps()`, mostly because I'm not 100% certain on the *intended* behavior vs *actual* behavior.

r? ghost